### PR TITLE
Removed the menu and added command line launching

### DIFF
--- a/Assets/1_SelfDrivingCar/Scripts/MenuOptions.cs
+++ b/Assets/1_SelfDrivingCar/Scripts/MenuOptions.cs
@@ -10,12 +10,13 @@ public class MenuOptions : MonoBehaviour
 
     public void Start ()
     {
-        outlines = GetComponentsInChildren<Outline>();
-		Debug.Log ("in menu script "+outlines.Length);
-		if (outlines.Length > 0) 
-		{
-			outlines [0].effectColor = new Color (0, 0, 0);
-		}
+		SceneManager.LoadScene("LakeTrackTraining");
+//         outlines = GetComponentsInChildren<Outline>();
+// 		Debug.Log ("in menu script "+outlines.Length);
+// 		if (outlines.Length > 0) 
+// 		{
+// 			outlines [0].effectColor = new Color (0, 0, 0);
+// 		}
     }
 
 	public void ControlMenu()

--- a/controller/drive.py
+++ b/controller/drive.py
@@ -106,8 +106,8 @@ def send_control(steering_angle, throttle):
         skip_sid=True)
 
 
-if __name__ == '__main__'
-    simulator=sp.Popen('exec open ./carsim_mac/Contents/MacOS/carsim_mac.app')
+if __name__ == '__main__':
+    simulator=sp.Popen('exec open ../carsim_mac/Contents/MacOS/carsim_mac.app')
     parser = argparse.ArgumentParser(description='Remote Driving')
     parser.add_argument(
         'model',

--- a/controller/drive.py
+++ b/controller/drive.py
@@ -12,6 +12,8 @@ import eventlet.wsgi
 from PIL import Image
 from flask import Flask
 from io import BytesIO
+import subprocess as sp
+import time
 
 from keras.models import load_model
 import h5py
@@ -105,6 +107,10 @@ def send_control(steering_angle, throttle):
 
 
 if __name__ == '__main__':
+    sp.Popen(['cd','~/Documents/Academics/Stanford/Q1/CS229/Project/self-driving-car-sim'], shell=True)
+    car=sp.Popen('exec open ./no_menu.app', shell=True)
+    print("Hello!\n")
+    time.sleep(15)
     parser = argparse.ArgumentParser(description='Remote Driving')
     parser.add_argument(
         'model',

--- a/controller/drive.py
+++ b/controller/drive.py
@@ -106,11 +106,8 @@ def send_control(steering_angle, throttle):
         skip_sid=True)
 
 
-if __name__ == '__main__':
-    sp.Popen(['cd','~/Documents/Academics/Stanford/Q1/CS229/Project/self-driving-car-sim'], shell=True)
-    car=sp.Popen('exec open ./no_menu.app', shell=True)
-    print("Hello!\n")
-    time.sleep(15)
+if __name__ == '__main__'
+    simulator=sp.Popen('exec open ./carsim_mac/Contents/MacOS/carsim_mac.app')
     parser = argparse.ArgumentParser(description='Remote Driving')
     parser.add_argument(
         'model',


### PR DESCRIPTION
Removed the menu and configured to directly jump into training mode on the lake track.

Also launched executable directly within drive.py

Simulator can be quit by adding in the line simulator.terminate() into the drive.py script when needed.